### PR TITLE
Bug fix: TrackerApi#delivered_stories_count

### DIFF
--- a/lib/status_fetcher.rb
+++ b/lib/status_fetcher.rb
@@ -55,7 +55,7 @@ module StatusFetcher
     return unless project.tracker_project?
 
     tracker = TrackerApi.new(project.tracker_auth_token)
-    project.tracker_num_unaccepted_stories = tracker.delivered_story_count(project.tracker_project_id)
+    project.tracker_num_unaccepted_stories = tracker.delivered_stories_count(project.tracker_project_id)
   end
 end
 

--- a/spec/lib/status_fetcher_spec.rb
+++ b/spec/lib/status_fetcher_spec.rb
@@ -154,7 +154,7 @@ describe StatusFetcher do
 
         before do
           TrackerApi.stub(:new).with(project.tracker_auth_token).and_return tracker_api
-          tracker_api.stub(:delivered_story_count).with(project.tracker_project_id).and_return 7
+          tracker_api.stub(:delivered_stories_count).with(project.tracker_project_id).and_return 7
         end
 
         it "should set the project's tracker_num_unaccepted_stories to the number of delivered stories" do


### PR DESCRIPTION
Method name is delivered_stories_count, but delivered_story_count was
being called
