### PR TITLE
add travis gem caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ notifications:
 rvm:
   - 2.0.0
 
+cache:
+  bundler: true
+
 before_script:
   - "sudo apt-get install memcached"
   - "bundle exec rake travis:setup"


### PR DESCRIPTION
This will use a ephemeral disk for the gems, should save on build time

as per http://about.travis-ci.org/docs/user/caching/
