### PR TITLE
Fix: parse the correct status url from teamcity JSON payload.

### DIFF
--- a/lib/payload/team_city_json_payload.rb
+++ b/lib/payload/team_city_json_payload.rb
@@ -20,8 +20,7 @@ class TeamCityJsonPayload < Payload
   end
 
   def parse_url(content)
-    self.parsed_url = "http://#{remote_addr}:8111/viewType.html?buildTypeId=#{parse_build_type_id(content)}"
-    "http://#{remote_addr}:8111/viewLog.html?buildId=#{parse_build_id(content)}&tab=buildResultsDiv&buildTypeId=#{parse_build_type_id(content)}"
+    self.parsed_url = content['buildStatusUrl']
   end
 
   def parse_build_type_id(content)


### PR DESCRIPTION
submit a fix for the incorrect teamcity build url issue.
