### PR TITLE
Changes Travis, Circle CI, and Semaphore payloads

### DIFF
--- a/lib/payload/circle_ci_payload.rb
+++ b/lib/payload/circle_ci_payload.rb
@@ -30,8 +30,8 @@ class CircleCiPayload < Payload
   end
 
   def parse_published_at(content)
-    if content['stop_time']
-      Time.parse(content['stop_time'])
+    if content['start_time']
+      Time.parse(content['start_time'])
     else
       Time.now
     end

--- a/lib/payload/semaphore_payload.rb
+++ b/lib/payload/semaphore_payload.rb
@@ -39,7 +39,7 @@ class SemaphorePayload < Payload
   end
 
   def parse_published_at(content)
-    Time.parse(content['finished_at']) if content['finished_at']
+    Time.parse(content['started_at']) if content['started_at']
   end
 
   private

--- a/lib/payload/travis_json_payload.rb
+++ b/lib/payload/travis_json_payload.rb
@@ -42,7 +42,7 @@ class TravisJsonPayload < Payload
   end
 
   def parse_published_at(content)
-    published_at = content['finished_at']
+    published_at = content['started_at']
     Time.parse(published_at) if published_at.present?
   end
 

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -112,7 +112,7 @@ describe StatusController do
         subject
         ProjectStatus.last.should_not be_success
         ProjectStatus.last.project_id.should == project.id
-        ProjectStatus.last.published_at.to_s.should == Time.utc(2013, 1, 21, 16, 15, 46).to_s
+        ProjectStatus.last.published_at.to_s.should == Time.utc(2013, 1, 21, 16, 12, 15).to_s
       end
 
       it "should update last_refreshed_at" do

--- a/spec/lib/payload/circle_ci_payload_spec.rb
+++ b/spec/lib/payload/circle_ci_payload_spec.rb
@@ -89,7 +89,7 @@ describe CircleCiPayload do
 
   describe '#parse_published_at' do
     subject { payload.parse_published_at(content).round }
-    it { should == Time.utc(2013, 10, 15, 8, 48, 51) }
+    it { should == Time.utc(2013, 10, 15, 8, 47, 30) }
   end
 
 end

--- a/spec/lib/payload/semaphore_payload_spec.rb
+++ b/spec/lib/payload/semaphore_payload_spec.rb
@@ -110,7 +110,7 @@ describe SemaphorePayload do
 
   describe '#parse_published_at' do
     subject { payload.parse_published_at(content) }
-    it { should == Time.new(2012, 8, 16, 2, 16, 46, "-07:00") }
+    it { should == Time.new(2012, 8, 16, 2, 15, 34, "-07:00") }
   end
 
 end

--- a/spec/lib/payload/travis_json_payload_spec.rb
+++ b/spec/lib/payload/travis_json_payload_spec.rb
@@ -128,7 +128,7 @@ describe TravisJsonPayload do
 
   describe '#parse_published_at' do
     subject { payload.parse_published_at(content) }
-    it { should == Time.utc(2013, 1, 22, 21, 20, 56) }
+    it { should == Time.utc(2013, 1, 22, 21, 16, 20) }
   end
 
   describe '#branch=' do


### PR DESCRIPTION
Payloads now use "started_at" values for published_at when creating project statuses.

There are also some payloads that have no information in their webhook request body to indicate a published_at timestamp. These payloads use Time.now, but could probably be a bit smarter about how they determine their published_at time.

Payloads without designated published_at timestamps:
- https://github.com/pivotal/projectmonitor/blob/master/lib/payload/jenkins_json_payload.rb#L40
- https://github.com/pivotal/projectmonitor/blob/master/lib/payload/team_city_json_payload.rb#L35

Payloads with ambiguous published_at timestamps:
- https://github.com/pivotal/projectmonitor/blob/5d8a5bbf3b13e8d4e68d61ff1cde12c92e933e40/lib/payload/tddium_payload.rb#L52
- https://github.com/pivotal/projectmonitor/blob/5d8a5bbf3b13e8d4e68d61ff1cde12c92e933e40/lib/payload/cruise_control_xml_payload.rb#L48
- https://github.com/pivotal/projectmonitor/blob/5d8a5bbf3b13e8d4e68d61ff1cde12c92e933e40/lib/payload/jenkins_xml_payload.rb#L55
- https://github.com/pivotal/projectmonitor/blob/5d8a5bbf3b13e8d4e68d61ff1cde12c92e933e40/lib/payload/legacy_team_city_xml_payload.rb#L38

Payloads with the correct value used for published_at:
- https://github.com/pivotal/projectmonitor/blob/master/lib/payload/team_city_xml_payload.rb#L42

We think we have fixed the immediate problem with regards to Travis CI builds, but would like some more context on how to go about fixing this across all types of project.
