### PR TITLE
Protocol-less reference to fonts.com.

### DIFF
--- a/app/views/layouts/home.html.haml
+++ b/app/views/layouts/home.html.haml
@@ -5,7 +5,7 @@
     = stylesheet_link_tag "application"
     = javascript_include_tag "application"
     = csrf_meta_tag
-    %script{:src => "http://fast.fonts.com/jsapi/14aea2b8-37b7-4a31-afb9-e44414bef419.js", :type => "text/javascript"}
+    %script{:src => "//fast.fonts.com/jsapi/14aea2b8-37b7-4a31-afb9-e44414bef419.js", :type => "text/javascript"}
   %body{:class => "dashboard tiles_#{@tiles_count}", "data-tiles-count" => @tiles_count}
     = yield
     #footer


### PR DESCRIPTION
This avoids blocked content warning when hosted on https.
