### PR TITLE
[docs] Fix broken link to Add Project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Click 'manage projects' at the lower right to edit project details.
 
 ### Add Projects
 
-We have instructions detailing [how to add a project](docs/configuration.md).
+We have instructions detailing [how to add a project](docs/adding_a_project.md).
 
 ### Importing and Exporting Configurations
 You can export your configuration for posterity or to be transferred to another


### PR DESCRIPTION
Introduced in https://github.com/pivotal/projectmonitor/commit/ca9d9db8b6077b839b10c82c407e19ea4d2927a3
