### PR TITLE
[docs] Remove extraneous Heroku config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ NB: These instructions are for the basic authentication strategy.
     heroku run rake db:migrate
     heroku config:add REST_AUTH_SITE_KEY=<unique, private and long alphanumeric key, e.g. abcd1234edfg78910>
     heroku config:add REST_AUTH_DIGEST_STRETCHES=<count of number of times to apply the digest, 10 recommended>
-    heroku labs:enable user-env-compile
     heroku run console 
 
 When inside the console, run the creating a new user step above. You should then be able to access your server and start using it.


### PR DESCRIPTION
When running this line, I get the error:

> projectmonitor (master)$ heroku labs:enable user-env-compile
>  !    No such feature: user-env-compile

Heroku has deprecated the user-env-compile lab since it's now default behavior.
