### PR TITLE
Fix exception in migrations by skipping validation.

### DIFF
--- a/db/migrate/20141103133449_consolidate_base_url_columns.rb
+++ b/db/migrate/20141103133449_consolidate_base_url_columns.rb
@@ -11,7 +11,7 @@ class ConsolidateBaseUrlColumns < ActiveRecord::Migration
     @@old_columns.each do |old_column|
       # Copy data across
       Project.where.not(old_column => nil).each do |project|
-        project.update(ci_base_url: project[old_column])
+        project.update_attribute(:ci_base_url, project[old_column])
       end
 
       # Prefix old columns with 'deprecated'

--- a/db/migrate/20141103165327_consolidate_project_and_build_name_columns.rb
+++ b/db/migrate/20141103165327_consolidate_project_and_build_name_columns.rb
@@ -11,7 +11,7 @@ class ConsolidateProjectAndBuildNameColumns < ActiveRecord::Migration
     @@old_columns.each do |old_column|
       # Copy data across
       Project.where.not(old_column => nil).each do |project|
-        project.update(ci_build_name: project[old_column])
+        project.update_attribute(:ci_build_name, project[old_column])
       end
 
       # Prefix old columns with 'deprecated'

--- a/db/migrate/20141104094442_consolidate_auth_token_columns.rb
+++ b/db/migrate/20141104094442_consolidate_auth_token_columns.rb
@@ -8,7 +8,7 @@ class ConsolidateAuthTokenColumns < ActiveRecord::Migration
     @@old_columns.each do |old_column|
       # Copy data across
       Project.where.not(old_column => nil).each do |project|
-        project.update(ci_auth_token: project[old_column])
+        project.update_attribute(:ci_auth_token, project[old_column])
       end
 
       # Prefix old columns with 'deprecated'


### PR DESCRIPTION
A bunch of recent migrations updated and then renamed attributes of the Project model. These migrations will raise exceptions because the Project model attempts to validate the new columns, which don't exist in the database until later migrations complete.

Solution is to skip validations within the migrations.
