### PR TITLE
wrap semaphore payload in an array and add tests

### DIFF
--- a/lib/payload/semaphore_payload.rb
+++ b/lib/payload/semaphore_payload.rb
@@ -21,7 +21,7 @@ class SemaphorePayload < Payload
   end
 
   def convert_webhook_content!(params)
-    extract_builds_if_build_history_url(params)
+    extract_builds_if_build_history_url(Array.wrap(params))
   end
 
   def parse_success(content)

--- a/spec/lib/payload/semaphore_payload_spec.rb
+++ b/spec/lib/payload/semaphore_payload_spec.rb
@@ -39,6 +39,26 @@ describe SemaphorePayload do
     end
   end
 
+  describe '#convert_webhook_content!' do
+    context 'the payload is an array containing a build hsitory' do
+      let(:fixture_file) { "success_history.json" }
+
+      let(:params) { [JSON.parse(fixture_content)] }
+
+      it "returns the first build content" do
+        expect(payload.convert_webhook_content!(params)).to eq params.first["builds"].first(15)
+      end
+    end
+
+    context 'the payload is just one build' do
+      let(:params) { JSON.parse(fixture_content) }
+
+      it "returns the payload" do
+        expect(payload.convert_webhook_content!(params)).to eq Array.wrap(params)
+      end
+    end
+  end
+
   describe '#parse_url' do
     it { expect(payload.parse_url(converted_content)).to eq('https://semaphoreapp.com/projects/123/branches/456/builds/1') }
   end


### PR DESCRIPTION
Semaphore webhooks were failing because extract_builds_if_build_history_url expects an array. Fix by wrapping the params in an array.

Also add some tests which seemed to be missing.
