### PR TITLE
Add link to tagged projects

### DIFF
--- a/app/views/configuration/edit.html.haml
+++ b/app/views/configuration/edit.html.haml
@@ -44,7 +44,9 @@
               %td
                 = project_last_status(project)
             %td.text-center= project.aggregate_project.present? ? project.aggregate_project.name : ""
-            %td.tag_list= project.tag_list
+            %td.tag_list
+              - project.tag_list.each do |tag|
+                = link_to tag, root_path({tags: tag})
             %td.age= project.updated_at.present? ? time_ago_in_words(project.updated_at) : "N/A"
             %td.webhooks.text-center= project.webhooks_enabled ? "✓" : "✕"
             %td.actions


### PR DESCRIPTION
-On a large system like pulse, it is hard for a user to know how to filter all the projects to just the ones needed for a single CI monitor. On the project configuration index page, this added a helper link to clue the user how to filter the root page