### PR TITLE
Update db:seed to parse admin creds from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ To deploy to production:
 cf push -f ./config/cf/manifest-production.yml
 ```
 
+You can specify the admin credentials by editing the `env` section in your manifest:
+```
+applications:
+- name: project-monitor-production
+  env:
+    PROJECT_MONITOR_LOGIN: REPLACE_WITH_ADMIN_LOGIN
+    PROJECT_MONITOR_EMAIL: REPLACE_WITH_ADMIN_EMAIL
+    PROJECT_MONITOR_PASSWORD: REPLACE_WITH_ADMIN_PASSWORD
+```
+
 ### Heroku
 To get running on Heroku, after you have cloned and bundled, run the following commands:
 

--- a/config/cf/manifest-production.yml
+++ b/config/cf/manifest-production.yml
@@ -5,10 +5,14 @@ applications:
   instances: 3
   host: project-monitor-production
   path: ../../
-  command: bundle exec rake db:migrate && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+  command: bundle exec rake db:migrate && bundle exec rake db:seed && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
   services:
   - db-production
   - logentries-production-web
+  env:
+    PROJECT_MONITOR_LOGIN: REPLACE_WITH_ADMIN_LOGIN
+    PROJECT_MONITOR_EMAIL: REPLACE_WITH_ADMIN_EMAIL
+    PROJECT_MONITOR_PASSWORD: REPLACE_WITH_ADMIN_PASSWORD
 - name: project-monitor-production-worker
   memory: 512M
   instances: 1

--- a/config/cf/manifest-staging.yml
+++ b/config/cf/manifest-staging.yml
@@ -5,10 +5,14 @@ applications:
   instances: 1
   host: project-monitor-staging
   path: ../../
-  command: bundle exec rake db:migrate && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+  command: bundle exec rake db:migrate && bundle exec rake db:seed && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
   services:
   - db-staging
   - logentries-staging-web
+  env:
+    PROJECT_MONITOR_LOGIN: REPLACE_WITH_ADMIN_LOGIN
+    PROJECT_MONITOR_EMAIL: REPLACE_WITH_ADMIN_EMAIL
+    PROJECT_MONITOR_PASSWORD: REPLACE_WITH_ADMIN_PASSWORD
 - name: project-monitor-staging-worker
   memory: 512M
   instances: 1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,13 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Daley', city: cities.first)
 
-User.create!(login: "admin", email: "admin@example.com", password: "password")
+# Create or update the admin user
+# The credentials can be specified through environment variables or by changing the default values below.
+login = ENV["PROJECT_MONITOR_LOGIN"] || "admin"
+email = ENV["PROJECT_MONITOR_EMAIL"] || "admin@example.com"
+password = ENV["PROJECT_MONITOR_PASSWORD"] || "password"
+
+user = User.where(login: login).first_or_initialize
+user.update(email: email, password: password)
+user.save


### PR DESCRIPTION
- Creating the admin user in CF is difficult since you cannot
  run a rails console in the app's container. This commit allows
  the credentials to be specified in the application manifest instead.