### PR TITLE
adjust ruby status page parsing and status handling for new ruby status page layout

### DIFF
--- a/app/assets/javascripts/rubygemsRefresh.js
+++ b/app/assets/javascripts/rubygemsRefresh.js
@@ -15,21 +15,21 @@ var RubyGemsRefresh = (function () {
         timeout: (pollIntervalSeconds - 1) * 1000,
         success: function(response) {
           var status = response.status;
-          if(status == 'good') {
+          if(status == 'none') {
             $rubygemsTile.slideUp();
             failureCount = 0;
           }
           else {
             failureCount++;
             if (failureCount >= failureThreshold) {
-              if (status == 'bad') {
-                RubyGemsRefresh.markAsDown();
-              }
-              else if(status == 'page broken') {
-                RubyGemsRefresh.markAsBroken();
-              }
-              else {
+              if (status == 'unreachable') {
                 RubyGemsRefresh.markAsUnreachable();
+              } else if (status == 'page broken') {
+                RubyGemsRefresh.markAsBroken();
+              } else if (status == 'minor') {
+                RubyGemsRefresh.markAsImpaired();
+              } else {
+                RubyGemsRefresh.markAsDown();
               }
             }
           }
@@ -43,6 +43,13 @@ var RubyGemsRefresh = (function () {
 
     cleanupTimeout : function () {
       clearTimeout(timeoutFunction);
+    },
+
+    markAsImpaired: function () {
+      $rubygemsTile.find('a').text("RUBYGEMS IS IMPAIRED");
+      RubyGemsRefresh.clearStatuses();
+      $rubygemsTile.addClass('impaired');
+      $rubygemsTile.slideDown();
     },
 
     markAsUnreachable: function () {
@@ -70,6 +77,7 @@ var RubyGemsRefresh = (function () {
       $rubygemsTile.removeClass('unreachable');
       $rubygemsTile.removeClass('bad');
       $rubygemsTile.removeClass('broken');
+      $rubygemsTile.removeClass('impaired')
     }
   };
 })();

--- a/app/models/external_dependency.rb
+++ b/app/models/external_dependency.rb
@@ -26,12 +26,15 @@ class ExternalDependency
 
       begin
         doc = Nokogiri::HTML(UrlRetriever.new('http://status.rubygems.org/').retrieve_content)
-        page_status = doc.at_css("span[class^='status__subheading']")
-
-        if page_status['class'].include? 'up'
-          output[:status] = 'good'
-        elsif page_status['class'].include? 'down'
-          output[:status] = 'bad'
+        page_status = doc.at_css("div[class~='page-status']") 
+        if page_status.nil?
+          stripped = 'invalid'
+        else
+          stripped = page_status['class'].sub!("page-status", "").sub!("status-","").strip!
+        end
+        @valid = "none;minor;major;critical"
+        if(@valid.include?(stripped))
+          output[:status] = stripped
         else
           output[:status] = 'page broken'
         end

--- a/spec/javascripts/rubygemsRefreshSpec.js
+++ b/spec/javascripts/rubygemsRefreshSpec.js
@@ -15,7 +15,7 @@ describe('RubyGemsRefresh.init', function() {
     jasmine.Ajax.uninstall();
   });
 
-  describe("when the status is bad", function() {
+  describe("when the status is critical", function() {
     it("shows the rubygems notification", function() {
       spyOn(RubyGemsRefresh, "clearStatuses");
       RubyGemsRefresh.init();
@@ -25,7 +25,7 @@ describe('RubyGemsRefresh.init', function() {
         jasmine.clock().tick(30001);
         jasmine.Ajax.requests.mostRecent().response({
           status: 200,
-          responseText: "{\"status\": \"bad\"}"
+          responseText: "{\"status\": \"critical\"}"
         });
       }
 
@@ -35,7 +35,47 @@ describe('RubyGemsRefresh.init', function() {
     });
   });
 
-  describe("when the status is good", function() {
+  describe("when the status is major", function() {
+    it("shows the rubygems notification", function() {
+      spyOn(RubyGemsRefresh, "clearStatuses");
+      RubyGemsRefresh.init();
+      expect($(".rubygems")).toBeHidden();
+
+      for (var i=0; i < 4; i++) {
+        jasmine.clock().tick(30001);
+        jasmine.Ajax.requests.mostRecent().response({
+          status: 200,
+          responseText: "{\"status\": \"major\"}"
+        });
+      }
+
+      expect($(".rubygems")).toBeVisible();
+      expect($(".rubygems")).toHaveClass('bad');
+      expect(RubyGemsRefresh.clearStatuses).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the status is minor", function() {
+    it("shows the rubygems impaired notification", function() {
+      spyOn(RubyGemsRefresh, "clearStatuses");
+      RubyGemsRefresh.init();
+      expect($(".rubygems")).toBeHidden();
+
+      for (var i=0; i < 4; i++) {
+        jasmine.clock().tick(30001);
+        jasmine.Ajax.requests.mostRecent().response({
+          status: 200,
+          responseText: "{\"status\": \"minor\"}"
+        });
+      }
+
+      expect($(".rubygems")).toBeVisible();
+      expect($(".rubygems")).toHaveClass('impaired');
+      expect(RubyGemsRefresh.clearStatuses).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the status is none", function() {
     it("does not show the rubygems notification", function() {
       RubyGemsRefresh.init();
       $(".rubygems").show();
@@ -43,7 +83,7 @@ describe('RubyGemsRefresh.init', function() {
       jasmine.clock().tick(30001);
       jasmine.Ajax.requests.mostRecent().response({
         status: 200,
-        responseText: "{\"status\": \"good\"}"
+        responseText: "{\"status\": \"none\"}"
       });
       expect($(".rubygems")).toBeHidden();
     });
@@ -64,6 +104,25 @@ describe('RubyGemsRefresh.init', function() {
       }
       expect($(".rubygems")).toBeVisible();
       expect($(".rubygems")).toHaveClass('unreachable');
+      expect(RubyGemsRefresh.clearStatuses).toHaveBeenCalled();
+    });
+  });
+
+  describe("when rubygems is unparsable", function() {
+    it("shows page broken notification", function() {
+      spyOn(RubyGemsRefresh, "clearStatuses");
+      RubyGemsRefresh.init();
+      expect($(".rubygems")).toBeHidden();
+
+      for (var i=0; i < 4; i++) {
+        jasmine.clock().tick(30001);
+        jasmine.Ajax.requests.mostRecent().response({
+          status: 200,
+          responseText: "{\"status\": \"page broken\"}"
+        });
+      }
+      expect($(".rubygems")).toBeVisible();
+      expect($(".rubygems")).toHaveClass('broken');
       expect(RubyGemsRefresh.clearStatuses).toHaveBeenCalled();
     });
   });

--- a/spec/models/external_dependency_spec.rb
+++ b/spec/models/external_dependency_spec.rb
@@ -41,16 +41,34 @@ describe ExternalDependency, :type => :model do
   end
 
   context 'rubygems status' do
-    it 'initialized an up status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<span class="status__subheading--up">UP</span>' }
+    it 'initialized an none status' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-none">All Systems Operational</div>' }
 
-      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"good\"}")
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"none\"}")
     end
 
-    it 'initialized a down status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<span class="status__subheading--down">DOWN</span>' }
+    it 'initialized a minor status' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-minor">Minor or something</div>' }
 
-      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"bad\"}")
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"minor\"}")
+    end
+
+    it 'initialized a major status' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-major">Major or something</div>' }
+
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"major\"}")
+    end
+
+    it 'initialized a critical status' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-critical">Critial or something</div>' }
+
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"critical\"}")
+    end
+
+    it 'initialized a page broken status' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div>Cannot find anything here</div>' }
+
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"page broken\"}")
     end
 
     it 'initialized an unreachable status when it recieved no response' do


### PR DESCRIPTION
The ruby status page changed its layout and stylesheet. Parsing failed always and the "unreachable" message constantly popped up.

I adjusted the html parsing for the new status values and css classes. I changed the javascript code for proper status handling. I added and modified the test cases to reflect and test the changes. 
