### PR TITLE
Use MySQL as the database

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,4 @@
-  class Project < ActiveRecord::Base
+class Project < ActiveRecord::Base
 
   RECENT_STATUS_COUNT = 8
   DEFAULT_POLLING_INTERVAL = 30
@@ -30,8 +30,8 @@
 
   scope :tracker_updateable, -> {
     enabled
-    .where.not(tracker_auth_token: [nil, ''])
-    .where.not(tracker_project_id: [nil, ''])
+      .where.not(tracker_auth_token: [nil, ''])
+      .where.not(tracker_project_id: [nil, ''])
   }
 
   scope :displayable, lambda { |tags = nil|
@@ -140,7 +140,8 @@
   def tracker_project?
     tracker_project_id.present? && tracker_auth_token.present?
   end
-  alias tracker_configured?  tracker_project?
+
+  alias tracker_configured? tracker_project?
 
   def payload
     raise NotImplementedError, 'Must implement payload in subclasses'
@@ -186,11 +187,11 @@
   def webhook_payload
     fetch_payload
   end
-  
+
   private
 
   def trim_urls_and_tokens
-    self.class.columns.select{|column| column.name.end_with?('_url', '_token') }.each do |column|
+    self.class.columns.select { |column| column.name.end_with?('_url', '_token') }.each do |column|
       write_attribute(column.name, read_attribute(column.name).try(:strip))
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,6 +45,8 @@
   validates :name, presence: true
   validates :type, presence: true
 
+  serialize :code
+
   before_create :generate_guid
   before_create :populate_iteration_story_state_counts
 

--- a/spec/features/api/projects_api_spec.rb
+++ b/spec/features/api/projects_api_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Projects API' do
   let(:user)                  { create(:user, password: 'jeffjeff') }
-  let(:red_project)           { Project.find_by(code: 'ALRE') }
+  let(:red_project)           { Project.find_by(name: 'Red Currently Building') }
   let(:aggregate_project)     { AggregateProject.find_by(name: 'Aggregation') }
   let!(:project_with_tracker) { create(:project_with_tracker_integration, code: "xxxx") }
 

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -31,12 +31,19 @@ feature "home" do
   context "aggregate projects" do
     let!(:aggregate) { create(:aggregate_project, code: 'GTFO', projects: [project]) }
     let!(:project) { create(:travis_project) }
+    let!(:emoji_project) { create(:travis_project, code: "\u{1F4A9}") }
 
     it "user sees the projects for an aggregate project", js: true do
       visit root_path
       click_on(aggregate.code)
 
       expect(page).to have_content(project.code)
+    end
+
+    it "renders emoji correctly", js: true do
+      visit root_path
+
+      expect(page).to have_content("\u{1F4A9}")
     end
   end
 end


### PR DESCRIPTION
As we are standardizing on using MySQL for Pivotal apps hosted on Cloud Foundry, we are changing Project Monitor to use this instead of Postgres.
- MySQL doesn't support default values for `TEXT` fields, so we default the value of `Project#iteration_story_state_counts` in Ruby
- turns out that MySQL's precision for `datetime` values is less than Postgres, so we have to fiddle the `created_at` value in some tests
- MySQL doesn't support `RANK() OVER(PARTITION BY...` style queries, so this has been replaced by a query based on [this Stackoverflow article](http://stackoverflow.com/questions/10881990/rank-function-in-mysql-with-order-by-clause)
# 

I will update this Pull Request once we're running this in production.
