### PR TITLE
Adds link to tagged aggregate projects

### DIFF
--- a/app/views/configuration/edit.html.haml
+++ b/app/views/configuration/edit.html.haml
@@ -76,7 +76,9 @@
                   ✓
                 - else
                   %span{style: 'color: #AA1224;'} ✕
-              %td.tag_list= aggregate_project.tag_list
+              %td.tag_list
+                - aggregate_project.tags.each do |tag|
+                  = link_to tag, root_path({tags: tag.name})
               %td.count= aggregate_project.projects.count
               %td.age= aggregate_project.updated_at.present? ? time_ago_in_words(aggregate_project.updated_at) : 'N/A'
               %td.actions


### PR DESCRIPTION
-On a large system like pulse, it is hard for a user to know how to filter all the projects to just the ones needed for a single CI monitor. On the project configuration index page, this adds a helper link to clue the user how to filter the root page

Similar to #79467915bb96ef190f388a1f54a7318d3fec0dab