### PR TITLE
Update nokogiri to 1.8.2 to fix CVE-2017-9050

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,9 @@ gem 'draper'
 gem 'sass-rails'
 gem 'bootstrap-sass'
 gem 'haml-rails'
+gem 'html2haml', '~> 2.2.0'
 gem 'jquery-rails'
-gem 'nokogiri'
+gem 'nokogiri', '1.8.2'
 
 gem 'oauth2', '0.8.1'
 gem 'omniauth', '1.1.4'
@@ -25,6 +26,7 @@ gem 'omniauth-oauth2', '1.1.1'
 
 gem 'pivotal-tracker'
 gem 'rails', '~> 4.2.6'
+gem 'rails-dom-testing', '~> 1.0.8'
 gem 'rake'
 gem 'whenever', require: false
 gem 'rails-backbone'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,16 +182,17 @@ GEM
       heroku-api (>= 0.1.2)
       json
       rake
-    html2haml (2.0.0)
+    html2haml (2.2.0)
       erubis (~> 2.7.0)
-      haml (~> 4.0.0)
-      nokogiri (~> 1.6.0)
+      haml (>= 4.0, < 6)
+      nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     httpauth (0.2.1)
-    i18n (0.7.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jasmine (2.4.0)
       jasmine-core (~> 2.4)
       phantomjs
@@ -206,7 +207,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jshint_on_rails (1.0.3)
-    json (1.8.3)
+    json (1.8.6)
     jwt (0.1.13)
       multi_json (>= 1.5)
     kgio (2.10.0)
@@ -230,17 +231,16 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     mysql2 (0.4.4)
     nenv (0.3.0)
     netrc (0.11.0)
     newrelic_rpm (3.16.0.318)
-    nokogiri (1.6.8)
-      mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     notiffany (0.1.0)
@@ -269,7 +269,6 @@ GEM
       nokogiri (>= 1.5.5)
       nokogiri-happymapper (>= 0.5.4)
       rest-client (>= 1.8.0)
-    pkg-config (1.1.7)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -303,9 +302,9 @@ GEM
       railties
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
-      activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -320,7 +319,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.16.0)
-    rake (11.2.2)
+    rake (12.3.1)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -350,8 +349,8 @@ GEM
     rspec-support (3.5.0)
     ruby-openid (2.7.0)
     ruby_dep (1.3.1)
-    ruby_parser (3.8.2)
-      sexp_processor (~> 4.1)
+    ruby_parser (3.11.0)
+      sexp_processor (~> 4.9)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.5)
@@ -360,7 +359,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sexp_processor (4.7.0)
+    sexp_processor (4.11.0)
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -380,10 +379,10 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
-    tilt (2.0.5)
+    thread_safe (0.3.6)
+    tilt (2.0.8)
     timecop (0.8.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
@@ -438,6 +437,7 @@ DEPENDENCIES
   guard-livereload
   haml-rails
   heroku_san
+  html2haml (~> 2.2.0)
   jasmine
   jbuilder
   jquery-rails
@@ -447,7 +447,7 @@ DEPENDENCIES
   lograge (~> 0.4)
   mysql2
   newrelic_rpm
-  nokogiri
+  nokogiri (= 1.8.2)
   oauth2 (= 0.8.1)
   omniauth (= 1.1.4)
   omniauth-google-oauth2 (= 0.2.0)
@@ -459,6 +459,7 @@ DEPENDENCIES
   quiet_assets
   rails (~> 4.2.6)
   rails-backbone
+  rails-dom-testing (~> 1.0.8)
   rails_12factor
   rake
   rb-fsevent
@@ -480,4 +481,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.16.1


### PR DESCRIPTION
Updated cascading dependencies. 