### PR TITLE
Fix flakey test by adding assertion that waits for the page load

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -19,7 +19,8 @@ feature "home" do
     it "should refresh the project collection", js: true do
       visit root_path
 
-      expect(page).to_not have_selector(".time-since-last-build", text: "4d")
+      expect(page).to have_selector(".time-since-last-build", text: "5d")
+      expect(page).not_to have_selector(".time-since-last-build", text: "4d")
 
       project.statuses << build(:project_status, success: true, build_id: 2, published_at: 4.days.ago)
       page.execute_script('window.ProjectMonitor.collectionData.projects.fetch()')


### PR DESCRIPTION
`not_to/to_not have_selector` does wait to the page to fully load and causes a race condition. We added another have_selector assertion to ensure that the page is in proper state before proceeding with the rest of the test.