### PR TITLE
Update loofah and rack-protection gems 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'omniauth', '~> 1.8.1'
 gem 'omniauth-google-oauth2', '0.5.3'
 gem 'omniauth-oauth2', '1.5.0'
 
+gem 'rack-protection', '1.5.5'
 gem 'pivotal-tracker'
 gem 'rails', '~> 4.2.6'
 gem 'rails-dom-testing', '~> 1.0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'haml-rails'
 gem 'html2haml', '~> 2.2.0'
 gem 'jquery-rails'
 gem 'nokogiri', '1.8.2'
+gem 'loofah', '2.2.2'
 
 gem 'oauth2', '1.4.0'
 gem 'omniauth', '~> 1.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.9)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -460,6 +460,7 @@ DEPENDENCIES
   pry-nav
   pry-rails
   quiet_assets
+  rack-protection (= 1.5.5)
   rails (~> 4.2.6)
   rails-backbone
   rails-dom-testing (~> 1.0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     cookiejar (0.3.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.4)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     delayed_job (4.1.2)
@@ -220,7 +221,8 @@ GEM
       actionpack (>= 4, < 5.1)
       activesupport (>= 4, < 5.1)
       railties (>= 4, < 5.1)
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
     mail (2.6.4)
@@ -445,6 +447,7 @@ DEPENDENCIES
   kramdown
   launchy
   lograge (~> 0.4)
+  loofah (= 2.2.2)
   mysql2
   newrelic_rpm
   nokogiri (= 1.8.2)


### PR DESCRIPTION
Github reports security vulnerabilities. Bumping gems to the latest versions. 

Cascading dependency (crass) updated as well.